### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -2,6 +2,9 @@ name: Running code coverage
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup environment
@@ -19,6 +22,8 @@ jobs:
     name: Run documentation
     runs-on: ubuntu-latest
     needs: setup # Need to wait for setup
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v1 # Get last commit pushed
 

--- a/.github/workflows/format-check-build.yml
+++ b/.github/workflows/format-check-build.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup environment

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,9 @@ on:
     branches-ignore:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup environment


### PR DESCRIPTION
Potential fix for [https://github.com/iamdevlinph/common-utils-pkg/security/code-scanning/8](https://github.com/iamdevlinph/common-utils-pkg/security/code-scanning/8)

Add an explicit `permissions` block at the workflow root in `.github/workflows/run-tests.yml`, directly under `on:` (or before `jobs:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe baseline is:

- `contents: read`

This satisfies CodeQL’s recommendation and preserves existing functionality since the workflow only checks out code, installs dependencies, caches, and runs tests. No new imports, methods, or definitions are needed (YAML workflow file only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
